### PR TITLE
Fixes entity inserts on postFlush for those entities with no entity i…

### DIFF
--- a/src/SimpleThings/EntityAudit/EventListener/LogRevisionsListener.php
+++ b/src/SimpleThings/EntityAudit/EventListener/LogRevisionsListener.php
@@ -122,6 +122,7 @@ class LogRevisionsListener implements EventSubscriber
     {
         foreach ($this->entityInserts as $entity) {
             $class = $this->em->getClassMetadata(\get_class($entity));
+            $entityData = array_merge($this->getOriginalEntityData($entity), $this->uow->getEntityIdentifier($entity));
             $this->saveRevisionEntityData($class, $this->getOriginalEntityData($entity), 'INS');
         }
 
@@ -172,6 +173,7 @@ class LogRevisionsListener implements EventSubscriber
         $this->entityDeletions =
         $this->entityInserts =
         $this->entityUpdates = [];
+        $this->revisionId = null;
     }
 
     /**

--- a/src/SimpleThings/EntityAudit/EventListener/LogRevisionsListener.php
+++ b/src/SimpleThings/EntityAudit/EventListener/LogRevisionsListener.php
@@ -123,7 +123,7 @@ class LogRevisionsListener implements EventSubscriber
         foreach ($this->entityInserts as $entity) {
             $class = $this->em->getClassMetadata(\get_class($entity));
             $entityData = array_merge($this->getOriginalEntityData($entity), $this->uow->getEntityIdentifier($entity));
-            $this->saveRevisionEntityData($class, $this->getOriginalEntityData($entity), 'INS');
+            $this->saveRevisionEntityData($class, $entityData, 'INS');
         }
 
         foreach ($this->entityUpdates as $entity) {


### PR DESCRIPTION
…dentifiers.

Two changes here: 1) the revisionId is resetted on postFlush, 2) there are cases when it is intended for an entity to subsequently create another entity, and as a result the correct entity identifier must be recalled from unit of work getEntityIdentifier function.

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Has tests?    | no
| Fixed tickets | #... <!-- #-prefixed issue number(s), if any -->

<!--
- Please fill in this template according to the PR you're about to submit.
- Replace this comment by a description of what your PR is solving.
-->